### PR TITLE
fix web healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       service: base
     command: sh -c "cabot migrate && gunicorn cabot.wsgi:application -b 0.0.0.0:5000 --workers=5"
     healthcheck:
-      test: "curl http://localhost:5000/status"
+      test: wget -qO- -T10 http://localhost:5000/status | grep -qc 'Checks running'
     ports:
       - '127.0.0.1:5000:5000'
     depends_on:


### PR DESCRIPTION
`curl` is not installed in the base image, however `wget` and `grep` are.