### PR TITLE
Add restart policy for Caddy (eg start Caddy when docker daemon boots/restarts)

### DIFF
--- a/docker-compose-caddy.yml
+++ b/docker-compose-caddy.yml
@@ -11,3 +11,4 @@ services:
     volumes:
       - ./.caddy:/root/.caddy
       - ./conf/Caddyfile:/etc/Caddyfile
+    restart: always


### PR DESCRIPTION
The Caddy container currently has no restart policy, meaning that if the host/Docker daemon restarts (or Caddy errors/quits for some reason), Caddy will be left offline and thus Cabot becomes inaccessible, requiring a manual start or restart to get Caddy online.  The other containers (https://github.com/cabotapp/docker-cabot/blob/master/docker-compose.yml) have restart policies of `always`; this PR adds the same for Caddy.