### PR TITLE
Unpin Postgres and set database password

### DIFF
--- a/conf/default.env
+++ b/conf/default.env
@@ -2,7 +2,7 @@ CABOT_PLUGINS_ENABLED=cabot_alert_hipchat,cabot_alert_twilio,cabot_alert_email,c
 
 DJANGO_SETTINGS_MODULE=cabot.settings
 
-DATABASE_URL=postgres://postgres@postgres:5432/postgres
+DATABASE_URL=postgres://postgres:postgres_password@postgres:5432/postgres
 CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
 
 # It will still log to STDOUT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,11 @@ services:
     restart: always
 
   postgres:
-    image: postgres:9.6.16-alpine
+    image: postgres:9.6-alpine
     volumes:
       - data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres_password
     restart: always
 
   rabbitmq:


### PR DESCRIPTION
There was a breaking change recently in Postgres Docker image [1],
where Postgres requires a password set.

As a quick fix, the postgres image was pinned
to the minor version 9.6.16 (before the change).

However, simply setting a password solves the issue
and is arguably a more robust way forward.

 - Set POSTGRES_PASSWORD environment variable to some password
   in the `postgres` container, via docker-compose

 - Update the `DATABASE_URL` connection string
   in `default.env` to include that password.

[1] Error message:
```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

Reverts 961d0f4e7b703bbce82f17dfb0958f48eba7b333